### PR TITLE
fix(deps): patch react-router 6.30.x + picomatch override

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,0 +1,67 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 0,
+  "workspaces": {
+    "": {
+      "name": "web-app",
+      "dependencies": {
+        "@babel/traverse": "^7.26.4",
+        "@emotion/is-prop-valid": "^1.3.1",
+        "@radix-ui/react-alert-dialog": "^1.0.5",
+        "@radix-ui/react-avatar": "^1.0.3",
+        "@radix-ui/react-checkbox": "^1.0.4",
+        "@radix-ui/react-collapsible": "^1.0.3",
+        "@radix-ui/react-dialog": "^1.0.5",
+        "@radix-ui/react-dropdown-menu": "^2.0.5",
+        "@radix-ui/react-label": "^2.0.2",
+        "@radix-ui/react-select": "^2.0.0",
+        "@radix-ui/react-slider": "^1.1.2",
+        "@radix-ui/react-slot": "^1.0.2",
+        "@radix-ui/react-tabs": "^1.0.4",
+        "@radix-ui/react-toast": "^1.1.5",
+        "@sentry/react": "^7.100.0",
+        "@supabase/supabase-js": "2.30.0",
+        "class-variance-authority": "^0.7.0",
+        "clsx": "^2.0.0",
+        "framer-motion": "^10.16.4",
+        "lucide-react": "^0.285.0",
+        "react": "18.2.0",
+        "react-dom": "18.2.0",
+        "react-helmet": "^6.1.0",
+        "react-router-dom": "^6.30.3",
+        "tailwind-merge": "^1.1.4",
+        "tailwindcss-animate": "^1.0.7",
+      },
+      "devDependencies": {
+        "@babel/generator": "^7.27.0",
+        "@babel/parser": "^7.27.0",
+        "@babel/types": "^7.27.0",
+        "@types/node": "^20.8.3",
+        "@types/react": "^18.2.15",
+        "@types/react-dom": "^18.2.7",
+        "@vitejs/plugin-react": "^4.0.3",
+        "autoprefixer": "^10.4.16",
+        "eslint": "^8.57.1",
+        "eslint-config-react-app": "^7.0.1",
+        "postcss": "^8.4.31",
+        "tailwindcss": "^3.3.3",
+        "terser": "^5.39.0",
+        "vite": "^4.4.5",
+      },
+    },
+  },
+  "overrides": {
+    "picomatch": "^2.3.2",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+  },
+  "packages": {
+    "@remix-run/router": ["@remix-run/router@1.23.2", "", {}, "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w=="],
+
+    "react-router": ["react-router@6.30.3", "", { "dependencies": { "@remix-run/router": "1.23.2" }, "peerDependencies": { "react": ">=16.8" } }, "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw=="],
+
+    "react-router-dom": ["react-router-dom@6.30.3", "", { "dependencies": { "@remix-run/router": "1.23.2", "react-router": "6.30.3" }, "peerDependencies": { "react": ">=16.8", "react-dom": ">=16.8" } }, "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag=="],
+
+    "picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -32,13 +32,14 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-helmet": "^6.1.0",
-    "react-router-dom": "6.16.0",
+    "react-router-dom": "^6.30.3",
     "tailwind-merge": "^1.1.4",
     "tailwindcss-animate": "^1.0.7"
   },
   "overrides": {
     "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "react-dom": "18.2.0",
+    "picomatch": "^2.3.2"
   },
   "devDependencies": {
     "@babel/generator": "^7.27.0",


### PR DESCRIPTION
## Summary

Two security advisories patched in this PR, both confirmed resolved by `bun audit` after changes.

---

### 1. react-router — GHSA-9jcx-v3wj-wh4m (moderate)

**Advisory:** React Router has unexpected external redirect via untrusted paths  
**Affected:** `react-router >=6.0.0 <6.30.2`  
**Fix:** Bumped `react-router-dom` from `6.16.0` → `^6.30.3` (latest stable 6.30.x patch, **not** crossing to 7.x — that major migration is a separate task).

Also resolved the companion advisory **GHSA-2w69-qvjg-hvjx** (XSS via Open Redirects in `@remix-run/router <=1.23.1`) which is fixed by the same version bump.

### 2. picomatch — high ReDoS (<2.3.2)

**Advisory:** picomatch ReDoS vulnerability  
**Affected:** `picomatch <2.3.2`, pulled transitively via `tailwindcss → fast-glob → micromatch → picomatch` and `eslint-config-react-app → @typescript-eslint/… → globby → fast-glob → micromatch → picomatch`  
**Fix:** Added `picomatch: "^2.3.2"` to the existing `overrides` block in `package.json`. Bun honours npm-compatible `overrides`.

---

### package.json diff

```diff
-    "react-router-dom": "6.16.0",
+    "react-router-dom": "^6.30.3",

   "overrides": {
     "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "react-dom": "18.2.0",
+    "picomatch": "^2.3.2"
   },
```

---

### bun audit — before vs after

**Before (targeted advisories):**
```
@remix-run/router  <=1.23.1
  high: React Router vulnerable to XSS via Open Redirects - GHSA-2w69-qvjg-hvjx

react-router  >=6.0.0 <6.30.2
  moderate: React Router has unexpected external redirect via untrusted paths - GHSA-9jcx-v3wj-wh4m

picomatch  <2.3.2
  tailwindcss › fast-glob › micromatch › picomatch
  eslint-config-react-app › @typescript-eslint/… › globby › fast-glob › micromatch › picomatch
  high: picomatch ReDoS
```

**After:** All three entries above are **gone** from `bun audit` output. ✅

Remaining advisories (35 total, unchanged) are pre-existing issues in pinned old versions of `vite`, `eslint-config-react-app`, `minimatch`, etc. — those are tracked for the major dep migrations (react-router 7, eslint 9 flat-config, Tailwind 4, Vite 6) documented in `docs/plans/2026-04-25-website-review-merged.md` Task 3.12.

---

### Build verification

- `bun run build` — **green** ✅ (2087 modules transformed, clean output)
- `bun run lint` — no lint script configured in this repo (no `.eslintrc` present); ESLint is a devDependency but not wired up as a script yet — not a regression introduced by this PR.

---

### Constraints respected

- Horizons-related code (`plugins/`, `vite.config.js` error handlers, `postMessage` patterns) — **untouched**
- `react-helmet` — **untouched** (replacement tracked in Task 2.1)
- `react-router-dom` stays on **6.x** — no 7.x crossing

https://claude.ai/code/session_017C97dAxr4b3nFZTTGFsLHT

---
_Generated by [Claude Code](https://claude.ai/code/session_017C97dAxr4b3nFZTTGFsLHT)_