### PR TITLE
[codex] Fix production first-load blank page

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -47,8 +47,10 @@ Convex backend email variables are set in the Convex dashboard:
 6. Purge the Hostinger/CDN cache after the new build is live, especially after
    Vite bundle changes. HTML is configured to revalidate, while hashed
    `/assets/` files are cached long-term.
-7. Verify `https://vivekapatel.com/` redirects to `https://www.vivekapatel.com/`
-   after the purge.
+7. Verify both `http://vivekapatel.com/` and `https://vivekapatel.com/` redirect
+   to `https://www.vivekapatel.com/` with query strings preserved after the purge.
+   Example: `https://vivekapatel.com/contact?source=test` should redirect to
+   `https://www.vivekapatel.com/contact?source=test`
 8. Verify `/`, `/contact`, `/robots.txt`, and `/sitemap.xml` on the live domain.
 9. Verify a missing asset such as `/assets/not-a-real-bundle.js` returns `404`
    instead of rewriting to the homepage.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -44,7 +44,14 @@ Convex backend email variables are set in the Convex dashboard:
 3. Wait for GitHub CI to pass.
 4. Merge to `main`.
 5. Hostinger Horizons auto-builds and refreshes the site.
-6. Verify `/`, `/contact`, `/robots.txt`, and `/sitemap.xml` on the live domain.
+6. Purge the Hostinger/CDN cache after the new build is live, especially after
+   Vite bundle changes. HTML is configured to revalidate, while hashed
+   `/assets/` files are cached long-term.
+7. Verify `https://vivekapatel.com/` redirects to `https://www.vivekapatel.com/`
+   after the purge.
+8. Verify `/`, `/contact`, `/robots.txt`, and `/sitemap.xml` on the live domain.
+9. Verify a missing asset such as `/assets/not-a-real-bundle.js` returns `404`
+   instead of rewriting to the homepage.
 
 For contact-form changes, submit one clearly marked QA lead only after explicit
 approval for live side effects, then confirm that the lead and email

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -3,7 +3,7 @@
   RewriteBase /
 
   RewriteCond %{HTTP_HOST} ^vivekapatel\.com$ [NC]
-  RewriteRule ^ https://www.vivekapatel.com%{REQUEST_URI} [R=301,L]
+  RewriteRule ^ https://www.vivekapatel.com%{REQUEST_URI} [R=301,L,QSA]
 
   # Missing hashed Vite assets must fail as 404s. Rewriting them to
   # index.html makes browsers reject module scripts as text/html.
@@ -20,7 +20,8 @@
   Header set X-Powered-By "Hostinger Horizons"
 
   # HTML must revalidate so mobile CDN variants do not keep stale bundle URLs.
-  Header set Cache-Control "no-cache, no-store, must-revalidate"
+  # Use no-cache instead of no-store to preserve bfcache for better back/forward UX.
+  Header set Cache-Control "no-cache, must-revalidate, max-age=0"
   
   # Hashed Vite assets are safe to cache aggressively.
   <If "%{REQUEST_URI} =~ m#^/assets/.*$#">

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,6 +1,16 @@
 <IfModule mod_rewrite.c>
   RewriteEngine On
   RewriteBase /
+
+  RewriteCond %{HTTP_HOST} ^vivekapatel\.com$ [NC]
+  RewriteRule ^ https://www.vivekapatel.com%{REQUEST_URI} [R=301,L]
+
+  # Missing hashed Vite assets must fail as 404s. Rewriting them to
+  # index.html makes browsers reject module scripts as text/html.
+  RewriteCond %{REQUEST_FILENAME} !-f
+  RewriteCond %{REQUEST_FILENAME} !-d
+  RewriteRule ^assets/ - [R=404,L]
+
   RewriteCond %{REQUEST_FILENAME} !-f
   RewriteCond %{REQUEST_FILENAME} !-d
   RewriteRule ^ index.html [L]
@@ -9,11 +19,11 @@
 <IfModule mod_headers.c>
   Header set X-Powered-By "Hostinger Horizons"
 
-  # Cache everything on CDN by default
-  Header set Cache-Control "public, s-maxage=604800, max-age=0"
+  # HTML must revalidate so mobile CDN variants do not keep stale bundle URLs.
+  Header set Cache-Control "no-cache, no-store, must-revalidate"
   
-  # Cache in browser all assets
+  # Hashed Vite assets are safe to cache aggressively.
   <If "%{REQUEST_URI} =~ m#^/assets/.*$#">
-    Header set Cache-Control "public, max-age=604800"
+    Header set Cache-Control "public, max-age=31536000, immutable"
   </If>
 </IfModule>

--- a/src/lib/convexClient.js
+++ b/src/lib/convexClient.js
@@ -86,7 +86,7 @@ export function resolveConvexClientConfig(
 
   return {
     issue,
-    shouldFailFast: Boolean(issue && isProduction),
+    shouldFailFast: false,
     url: issue ? null : value,
   };
 }
@@ -121,12 +121,6 @@ function createDisabledConvexClient(reason = LOCAL_DEVELOPMENT_MESSAGE) {
 }
 
 function createConvexClient(config) {
-  if (config.shouldFailFast) {
-    throw new Error(
-      `${config.issue} Refusing to start the production app until Convex is configured.`,
-    );
-  }
-
   if (config.issue) {
     console.warn(`${config.issue} ${LOCAL_DEVELOPMENT_MESSAGE}`);
     return createDisabledConvexClient(

--- a/src/lib/convexClient.test.js
+++ b/src/lib/convexClient.test.js
@@ -34,10 +34,10 @@ describe('resolveConvexClientConfig', () => {
     });
   });
 
-  it('fails fast in production without a Convex URL', () => {
+  it('keeps production bootable without a Convex URL', () => {
     expect(resolveConvexClientConfig('', { isProduction: true })).toEqual({
       issue: 'Missing VITE_CONVEX_URL.',
-      shouldFailFast: true,
+      shouldFailFast: false,
       url: null,
     });
   });
@@ -49,7 +49,7 @@ describe('resolveConvexClientConfig', () => {
     ]) {
       expect(resolveConvexClientConfig(url, { isProduction: true })).toEqual({
         issue: 'VITE_CONVEX_URL still contains a placeholder value.',
-        shouldFailFast: true,
+        shouldFailFast: false,
         url: null,
       });
     }
@@ -62,7 +62,7 @@ describe('resolveConvexClientConfig', () => {
       }),
     ).toEqual({
       issue: 'Production VITE_CONVEX_URL must use https://.',
-      shouldFailFast: true,
+      shouldFailFast: false,
       url: null,
     });
   });
@@ -74,7 +74,7 @@ describe('resolveConvexClientConfig', () => {
       }),
     ).toEqual({
       issue: 'Production VITE_CONVEX_URL must point to a convex.cloud deployment.',
-      shouldFailFast: true,
+      shouldFailFast: false,
       url: null,
     });
   });
@@ -86,7 +86,7 @@ describe('resolveConvexClientConfig', () => {
       }),
     ).toEqual({
       issue: 'Production VITE_CONVEX_URL must point to a convex.cloud deployment.',
-      shouldFailFast: true,
+      shouldFailFast: false,
       url: null,
     });
   });
@@ -99,7 +99,7 @@ describe('resolveConvexClientConfig', () => {
     ]) {
       expect(resolveConvexClientConfig(url, { isProduction: true })).toEqual({
         issue: 'Production VITE_CONVEX_URL must not include a path, query, or hash.',
-        shouldFailFast: true,
+        shouldFailFast: false,
         url: null,
       });
     }
@@ -112,7 +112,7 @@ describe('resolveConvexClientConfig', () => {
     ]) {
       expect(resolveConvexClientConfig(url, { isProduction: true })).toEqual({
         issue: 'Production VITE_CONVEX_URL must not include an explicit port.',
-        shouldFailFast: true,
+        shouldFailFast: false,
         url: null,
       });
     }
@@ -125,7 +125,7 @@ describe('resolveConvexClientConfig', () => {
     ]) {
       expect(resolveConvexClientConfig(url, { isProduction: true })).toEqual({
         issue: 'Production VITE_CONVEX_URL must not include credentials.',
-        shouldFailFast: true,
+        shouldFailFast: false,
         url: null,
       });
     }

--- a/tests/qa/qa-edge.spec.js
+++ b/tests/qa/qa-edge.spec.js
@@ -94,6 +94,18 @@ test('rapid route switching does not crash', async ({ page }) => {
   expect(errors).toEqual([]);
 });
 
+test('fetch instrumentation supports URL objects', async ({ page }) => {
+  const errors = [];
+  page.on('pageerror', (e) => errors.push(e.message));
+  await page.goto('/');
+  const status = await page.evaluate(async () => {
+    const response = await fetch(new URL('/robots.txt', window.location.href));
+    return response.status;
+  });
+  expect(status).toBe(200);
+  expect(errors).toEqual([]);
+});
+
 test('legal pages are scrollable to footer', async ({ page }) => {
   await page.goto('/legal');
   await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));

--- a/vite.config.js
+++ b/vite.config.js
@@ -104,7 +104,14 @@ const configWindowFetchMonkeyPatch = `
 const originalFetch = window.fetch;
 
 window.fetch = function(...args) {
-	const url = args[0] instanceof Request ? args[0].url : String(args[0]);
+	const firstArg = args[0];
+	
+	// Let native fetch handle missing or invalid arguments
+	if (!firstArg) {
+		return originalFetch.apply(this, args);
+	}
+	
+	const url = firstArg instanceof Request ? firstArg.url : String(firstArg);
 
 	// Skip WebSocket URLs
 	if (url.startsWith('ws:') || url.startsWith('wss:')) {

--- a/vite.config.js
+++ b/vite.config.js
@@ -104,7 +104,7 @@ const configWindowFetchMonkeyPatch = `
 const originalFetch = window.fetch;
 
 window.fetch = function(...args) {
-	const url = args[0] instanceof Request ? args[0].url : args[0];
+	const url = args[0] instanceof Request ? args[0].url : String(args[0]);
 
 	// Skip WebSocket URLs
 	if (url.startsWith('ws:') || url.startsWith('wss:')) {


### PR DESCRIPTION
## Summary
- Redirect apex `vivekapatel.com` traffic to canonical `www.vivekapatel.com`.
- Stop missing Vite asset requests from rewriting to `index.html` and set HTML to revalidate.
- Keep the React app bootable when Convex frontend config is missing or malformed.
- Add QA coverage for the fetch instrumentation URL-object edge case and document CDN purge checks.

## Root Cause
The live apex domain was serving stale cached HTML from Hostinger CDN that referenced old hashed Vite assets. Those missing asset URLs were rewritten to HTML with `content-type: text/html`, so the browser rejected the module script and React never mounted, leaving `#root` empty on first load.

## Validation
- `npm test` passed: 41 tests.
- `npm run build` passed.
- `npx playwright test -c tests/qa/qa.config.js --project=preview-mobile tests/qa/qa-responsive.spec.js tests/qa/qa-edge.spec.js` passed: 18 passed, 1 skipped.
- Reproduced the blank page on `https://vivekapatel.com/` and confirmed the stale asset rewrite behavior via direct CDN response checks.