### PR TITLE
Redesign V3: Bold Creative — CV-themed canvas experience, zero dependencies

### DIFF
--- a/src/components/CustomCursor.jsx
+++ b/src/components/CustomCursor.jsx
@@ -2,9 +2,18 @@ import React, { useEffect, useState } from 'react';
 import useMousePosition from '@/hooks/useMousePosition';
 import { motion } from 'framer-motion';
 
+const INTERACTIVE_SELECTOR =
+  'a, button, [role="button"], input, select, textarea, summary, [data-cursor-target]';
+
+const IDLE_FRAME_SIZE = 36;
+const FRAME_PADDING = 6;
+
+const bracketBase = 'absolute h-3 w-3 border-[#9372FF]';
+
 const CustomCursor = () => {
   const { x, y } = useMousePosition();
   const [enabled, setEnabled] = useState(false);
+  const [hoverTarget, setHoverTarget] = useState(null);
 
   useEffect(() => {
     const pointerQuery = window.matchMedia('(pointer: fine)');
@@ -46,28 +55,74 @@ const CustomCursor = () => {
     };
   }, []);
 
-  const variants = {
-    default: {
-      x: x - 8,
-      y: y - 8,
-      height: 16,
-      width: 16,
-      backgroundColor: '#9372FF', // Updated to the new purple
-      mixBlendMode: 'difference',
-    },
-  };
+  useEffect(() => {
+    if (!enabled) {
+      setHoverTarget(null);
+      return undefined;
+    }
+
+    const handleMouseOver = (event) => {
+      const element =
+        event.target instanceof Element
+          ? event.target.closest(INTERACTIVE_SELECTOR)
+          : null;
+      setHoverTarget(element);
+    };
+    // Element rects go stale while scrolling; release the snap until the next hover.
+    const clearTarget = () => setHoverTarget(null);
+
+    document.addEventListener('mouseover', handleMouseOver);
+    window.addEventListener('scroll', clearTarget, true);
+
+    return () => {
+      document.removeEventListener('mouseover', handleMouseOver);
+      window.removeEventListener('scroll', clearTarget, true);
+    };
+  }, [enabled]);
 
   if (!enabled) {
     return null;
   }
 
+  const snapped = Boolean(hoverTarget && hoverTarget.isConnected);
+  let frame = {
+    x: x - IDLE_FRAME_SIZE / 2,
+    y: y - IDLE_FRAME_SIZE / 2,
+    width: IDLE_FRAME_SIZE,
+    height: IDLE_FRAME_SIZE,
+  };
+  if (snapped) {
+    const rect = hoverTarget.getBoundingClientRect();
+    frame = {
+      x: rect.left - FRAME_PADDING,
+      y: rect.top - FRAME_PADDING,
+      width: rect.width + FRAME_PADDING * 2,
+      height: rect.height + FRAME_PADDING * 2,
+    };
+  }
+
   return (
-    <motion.div
-      variants={variants}
-      animate="default"
-      transition={{ type: "spring", stiffness: 500, damping: 28 }}
-      className="fixed top-0 left-0 rounded-full pointer-events-none z-[9999]"
-    />
+    <>
+      <motion.div
+        aria-hidden="true"
+        animate={{ ...frame, opacity: snapped ? 1 : 0.75 }}
+        transition={{ type: 'spring', stiffness: 400, damping: 30 }}
+        className="fixed top-0 left-0 pointer-events-none z-[9999]"
+        style={{ mixBlendMode: 'difference' }}
+      >
+        <span className={`${bracketBase} left-0 top-0 border-l-2 border-t-2`} />
+        <span className={`${bracketBase} right-0 top-0 border-r-2 border-t-2`} />
+        <span className={`${bracketBase} left-0 bottom-0 border-l-2 border-b-2`} />
+        <span className={`${bracketBase} right-0 bottom-0 border-r-2 border-b-2`} />
+      </motion.div>
+      <motion.div
+        aria-hidden="true"
+        animate={{ x: x - 4, y: y - 4 }}
+        transition={{ type: 'spring', stiffness: 800, damping: 40 }}
+        className="fixed top-0 left-0 h-2 w-2 rounded-full bg-[#9372FF] pointer-events-none z-[9999]"
+        style={{ mixBlendMode: 'difference' }}
+      />
+    </>
   );
 };
 

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -1,30 +1,58 @@
 import React from 'react';
-import { motion } from 'framer-motion';
+import { motion, useReducedMotion } from 'framer-motion';
 import { ArrowRight, Sparkles } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useNavigate } from 'react-router-dom';
-import AnimatedHeroBackground from '@/components/AnimatedHeroBackground';
+import ParticleConstellation from '@/components/ParticleConstellation';
 import { socialLinks } from '@/config/links';
+
+const KineticLine = ({ text, className = '', wordClassName = '', baseDelay = 0, reduceMotion }) => {
+  if (reduceMotion) {
+    return <span className={`${className} ${wordClassName}`.trim()}>{text}</span>;
+  }
+
+  const words = text.split(' ');
+  return (
+    <span className={className}>
+      {words.map((word, index) => (
+        <span key={`${word}-${index}`} className="inline-block whitespace-pre">
+          <motion.span
+            className={`inline-block will-change-transform ${wordClassName}`.trim()}
+            initial={{ y: '0.6em', opacity: 0, filter: 'blur(8px)' }}
+            animate={{ y: '0em', opacity: 1, filter: 'blur(0px)' }}
+            transition={{
+              duration: 0.7,
+              delay: baseDelay + index * 0.07,
+              ease: [0.22, 1, 0.36, 1],
+            }}
+          >
+            {word}
+          </motion.span>
+          {index < words.length - 1 ? ' ' : null}
+        </span>
+      ))}
+    </span>
+  );
+};
 
 const Hero = () => {
   const navigate = useNavigate();
+  const reduceMotion = useReducedMotion();
 
   const handleCTAClick = () => {
     navigate('/contact');
   };
 
-  const handleViewWorkClick = () => {
-    const portfolioSection = document.getElementById('portfolio');
-    if (portfolioSection) {
-      portfolioSection.scrollIntoView({
-        behavior: 'smooth'
-      });
-    }
-  };
-
   return (
-    <section className="relative min-h-screen flex items-center justify-center overflow-hidden pt-20">
-      <AnimatedHeroBackground />
+    <section className="relative min-h-screen flex items-center justify-center overflow-hidden pt-20 bg-[#0C0D0D]">
+      <div className="absolute inset-0 cv-grid" aria-hidden="true"></div>
+      <div className="absolute inset-0" aria-hidden="true">
+        <ParticleConstellation />
+      </div>
+      <div
+        className="absolute inset-0 bg-[radial-gradient(ellipse_at_center,rgba(124,58,237,0.12),transparent_65%)]"
+        aria-hidden="true"
+      ></div>
       <div className="absolute inset-0 bg-black/40"></div>
 
       <div className="container mx-auto px-6 relative z-10">
@@ -56,15 +84,21 @@ const Hero = () => {
             </a>
           </motion.div>
 
-          <motion.h1
-            initial={{ opacity: 0, y: 30 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.8, delay: 0.2 }}
-            className="text-4xl sm:text-5xl md:text-7xl lg:text-8xl font-bold mb-6 leading-tight text-white uppercase break-words"
+          <h1
+            className="glitch-hover text-4xl sm:text-5xl md:text-7xl lg:text-8xl font-bold mb-6 leading-tight text-white uppercase break-words"
+            aria-label="Vivek Patel Computer Vision & AI Engineer"
           >
-            Vivek Patel
-            <span className="block text-accent-purple">Computer Vision & AI Engineer</span>
-          </motion.h1>
+            <span aria-hidden="true">
+              <KineticLine text="Vivek Patel" baseDelay={0.2} reduceMotion={reduceMotion} />
+              <KineticLine
+                text="Computer Vision & AI Engineer"
+                className="block"
+                wordClassName="text-gradient"
+                baseDelay={0.4}
+                reduceMotion={reduceMotion}
+              />
+            </span>
+          </h1>
 
           <motion.p
             initial={{ opacity: 0, y: 30 }}

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -4,6 +4,7 @@ import Header from '@/components/Header';
 import Footer from '@/components/Footer';
 import { Toaster } from '@/components/ui/toaster';
 import CustomCursor from '@/components/CustomCursor';
+import ScrollProgressBar from '@/components/ScrollProgressBar';
 import GoogleAnalytics from '@/components/GoogleAnalytics';
 import SentryTelemetry from '@/components/SentryTelemetry';
 import CookieConsentBanner from '@/components/CookieConsentBanner';
@@ -54,6 +55,7 @@ const Layout = () => {
       >
         Skip to main content
       </a>
+      <ScrollProgressBar />
       <CustomCursor />
       <GoogleAnalytics hasConsent={gaConsent} />
       <SentryTelemetry hasConsent={gaConsent} />

--- a/src/components/ParticleConstellation.jsx
+++ b/src/components/ParticleConstellation.jsx
@@ -1,0 +1,278 @@
+import React, { useEffect, useRef } from 'react';
+
+/**
+ * Hand-rolled Canvas 2D particle constellation, styled after computer-vision
+ * feature-point matching: drifting keypoints, proximity link lines, mouse
+ * repulsion, and an occasional "detection" flourish (bounding box + corner
+ * brackets + confidence label).
+ *
+ * Performance/accessibility contract:
+ * - particle count scales with viewport area (lower density on coarse pointers)
+ * - devicePixelRatio capped at 2
+ * - rAF paused when the tab is hidden or the canvas scrolls offscreen
+ * - prefers-reduced-motion renders a single static frame (no animation loop)
+ */
+
+const LINK_DISTANCE = 120;
+const MOUSE_RADIUS = 150;
+const DETECTION_DURATION = 1600;
+const DETECTION_LABELS = ['match: 0.98', 'feat: 0.94', 'obj: 0.97', 'track: 0.96'];
+
+const ParticleConstellation = ({ className = '' }) => {
+  const canvasRef = useRef(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return undefined;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return undefined;
+
+    const reducedMotion = window.matchMedia?.('(prefers-reduced-motion: reduce)')?.matches ?? false;
+    const finePointer = window.matchMedia?.('(pointer: fine)')?.matches ?? false;
+
+    let width = 0;
+    let height = 0;
+    let particles = [];
+    let rafId = null;
+    let running = false;
+    let pageVisible = !document.hidden;
+    let onScreen = true;
+    let lastTime = 0;
+    let detection = null;
+    let nextDetectionAt = 0;
+    const mouse = { x: null, y: null };
+
+    const rand = (min, max) => min + Math.random() * (max - min);
+
+    const buildParticles = () => {
+      const density = finePointer ? 15000 : 26000;
+      const cap = finePointer ? 110 : 55;
+      const count = Math.max(24, Math.min(Math.round((width * height) / density), cap));
+      particles = Array.from({ length: count }, () => ({
+        x: rand(0, width),
+        y: rand(0, height),
+        vx: rand(-0.16, 0.16),
+        vy: rand(-0.16, 0.16),
+        r: rand(1, 2.2),
+      }));
+    };
+
+    const drawLinks = () => {
+      for (let i = 0; i < particles.length; i += 1) {
+        for (let j = i + 1; j < particles.length; j += 1) {
+          const a = particles[i];
+          const b = particles[j];
+          const dx = a.x - b.x;
+          const dy = a.y - b.y;
+          const dist = Math.hypot(dx, dy);
+          if (dist < LINK_DISTANCE) {
+            const alpha = (1 - dist / LINK_DISTANCE) * 0.22;
+            ctx.strokeStyle = `rgba(147, 114, 255, ${alpha.toFixed(3)})`;
+            ctx.lineWidth = 1;
+            ctx.beginPath();
+            ctx.moveTo(a.x, a.y);
+            ctx.lineTo(b.x, b.y);
+            ctx.stroke();
+          }
+        }
+      }
+    };
+
+    const drawParticles = () => {
+      for (const p of particles) {
+        ctx.fillStyle = 'rgba(190, 165, 255, 0.55)';
+        ctx.beginPath();
+        ctx.arc(p.x, p.y, p.r, 0, Math.PI * 2);
+        ctx.fill();
+      }
+    };
+
+    const drawDetection = (now) => {
+      if (!detection) return;
+      const progress = (now - detection.start) / DETECTION_DURATION;
+      if (progress >= 1) {
+        detection = null;
+        nextDetectionAt = now + rand(2600, 5200);
+        return;
+      }
+      const alpha = Math.sin(Math.PI * progress) * 0.55;
+      const { x, y, w, h, label } = detection;
+      const bracket = Math.min(14, w * 0.25);
+
+      ctx.strokeStyle = `rgba(147, 114, 255, ${(alpha * 0.5).toFixed(3)})`;
+      ctx.lineWidth = 1;
+      ctx.strokeRect(x, y, w, h);
+
+      ctx.strokeStyle = `rgba(212, 180, 255, ${alpha.toFixed(3)})`;
+      ctx.lineWidth = 1.5;
+      const corners = [
+        [x, y, 1, 1],
+        [x + w, y, -1, 1],
+        [x, y + h, 1, -1],
+        [x + w, y + h, -1, -1],
+      ];
+      for (const [cx, cy, dirX, dirY] of corners) {
+        ctx.beginPath();
+        ctx.moveTo(cx + bracket * dirX, cy);
+        ctx.lineTo(cx, cy);
+        ctx.lineTo(cx, cy + bracket * dirY);
+        ctx.stroke();
+      }
+
+      ctx.fillStyle = `rgba(212, 180, 255, ${alpha.toFixed(3)})`;
+      ctx.font = '10px ui-monospace, SFMono-Regular, Menlo, monospace';
+      ctx.fillText(label, x, Math.max(10, y - 6));
+    };
+
+    const maybeStartDetection = (now) => {
+      if (detection || reducedMotion || now < nextDetectionAt || particles.length === 0) return;
+      const anchor = particles[Math.floor(Math.random() * particles.length)];
+      const w = rand(64, 110);
+      const h = rand(50, 90);
+      detection = {
+        x: Math.min(Math.max(anchor.x - w / 2, 8), Math.max(8, width - w - 8)),
+        y: Math.min(Math.max(anchor.y - h / 2, 16), Math.max(16, height - h - 8)),
+        w,
+        h,
+        start: now,
+        label: DETECTION_LABELS[Math.floor(Math.random() * DETECTION_LABELS.length)],
+      };
+    };
+
+    const update = (dt) => {
+      const step = Math.min(dt, 48) / 16.67;
+      for (const p of particles) {
+        p.x += p.vx * step;
+        p.y += p.vy * step;
+
+        if (mouse.x !== null) {
+          const dx = p.x - mouse.x;
+          const dy = p.y - mouse.y;
+          const dist = Math.hypot(dx, dy);
+          if (dist > 0.5 && dist < MOUSE_RADIUS) {
+            const force = ((MOUSE_RADIUS - dist) / MOUSE_RADIUS) * 0.6 * step;
+            p.x += (dx / dist) * force;
+            p.y += (dy / dist) * force;
+          }
+        }
+
+        if (p.x < -8) p.x = width + 8;
+        if (p.x > width + 8) p.x = -8;
+        if (p.y < -8) p.y = height + 8;
+        if (p.y > height + 8) p.y = -8;
+      }
+    };
+
+    const drawFrame = (now) => {
+      ctx.clearRect(0, 0, width, height);
+      drawLinks();
+      drawParticles();
+      drawDetection(now);
+    };
+
+    const tick = (now) => {
+      rafId = null;
+      if (!running) return;
+      const dt = lastTime ? now - lastTime : 16.67;
+      lastTime = now;
+      update(dt);
+      maybeStartDetection(now);
+      drawFrame(now);
+      rafId = requestAnimationFrame(tick);
+    };
+
+    const syncRunning = () => {
+      const shouldRun = !reducedMotion && pageVisible && onScreen;
+      if (shouldRun && !running) {
+        running = true;
+        lastTime = 0;
+        rafId = requestAnimationFrame(tick);
+      } else if (!shouldRun && running) {
+        running = false;
+        if (rafId !== null) {
+          cancelAnimationFrame(rafId);
+          rafId = null;
+        }
+      }
+    };
+
+    const resize = () => {
+      const rect = canvas.getBoundingClientRect();
+      width = rect.width;
+      height = rect.height;
+      const dpr = Math.min(window.devicePixelRatio || 1, 2);
+      canvas.width = Math.max(1, Math.round(width * dpr));
+      canvas.height = Math.max(1, Math.round(height * dpr));
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      buildParticles();
+      if (reducedMotion) {
+        drawFrame(performance.now());
+      }
+    };
+
+    const handleVisibility = () => {
+      pageVisible = !document.hidden;
+      syncRunning();
+    };
+
+    const handlePointerMove = (event) => {
+      const rect = canvas.getBoundingClientRect();
+      const x = event.clientX - rect.left;
+      const y = event.clientY - rect.top;
+      if (x < 0 || y < 0 || x > rect.width || y > rect.height) {
+        mouse.x = null;
+        mouse.y = null;
+      } else {
+        mouse.x = x;
+        mouse.y = y;
+      }
+    };
+
+    const handlePointerLeave = () => {
+      mouse.x = null;
+      mouse.y = null;
+    };
+
+    resize();
+    window.addEventListener('resize', resize);
+    document.addEventListener('visibilitychange', handleVisibility);
+
+    let observer = null;
+    if (typeof IntersectionObserver === 'function') {
+      observer = new IntersectionObserver((entries) => {
+        onScreen = entries.some((entry) => entry.isIntersecting);
+        syncRunning();
+      });
+      observer.observe(canvas);
+    }
+
+    if (finePointer && !reducedMotion) {
+      window.addEventListener('pointermove', handlePointerMove, { passive: true });
+      document.documentElement.addEventListener('pointerleave', handlePointerLeave);
+    }
+
+    syncRunning();
+
+    return () => {
+      running = false;
+      if (rafId !== null) cancelAnimationFrame(rafId);
+      window.removeEventListener('resize', resize);
+      document.removeEventListener('visibilitychange', handleVisibility);
+      if (observer) observer.disconnect();
+      if (finePointer && !reducedMotion) {
+        window.removeEventListener('pointermove', handlePointerMove);
+        document.documentElement.removeEventListener('pointerleave', handlePointerLeave);
+      }
+    };
+  }, []);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      className={`h-full w-full ${className}`.trim()}
+      aria-hidden="true"
+    />
+  );
+};
+
+export default ParticleConstellation;

--- a/src/components/Portfolio.jsx
+++ b/src/components/Portfolio.jsx
@@ -1,12 +1,35 @@
 import React from 'react';
+import { motion, useReducedMotion } from 'framer-motion';
 import { ArrowUpRight } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import { featuredCaseStudies } from '@/data/caseStudies';
 
-const ProjectCard = ({ project }) => {
+const CONFIDENCE_VALUES = ['0.98', '0.96', '0.99', '0.97', '0.95', '0.94'];
+
+// framer-motion's whileInView requires IntersectionObserver (missing in jsdom).
+const canObserveViewport = () =>
+  typeof window !== 'undefined' && typeof window.IntersectionObserver === 'function';
+
+const AnalysisOverlay = ({ confidence }) => (
+  <div
+    className="pointer-events-none absolute inset-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100"
+    aria-hidden="true"
+  >
+    <span className="absolute left-3 top-3 h-5 w-5 border-l-2 border-t-2 border-[#9372FF]" />
+    <span className="absolute right-3 top-3 h-5 w-5 border-r-2 border-t-2 border-[#9372FF]" />
+    <span className="absolute bottom-3 left-3 h-5 w-5 border-b-2 border-l-2 border-[#9372FF]" />
+    <span className="absolute bottom-3 right-3 h-5 w-5 border-b-2 border-r-2 border-[#9372FF]" />
+    <span className="cv-card-scanline absolute inset-x-0 top-0 h-px" />
+    <span className="absolute right-3 bottom-3 rounded bg-black/70 px-2 py-0.5 font-mono text-[11px] tracking-wider text-[#d8caff]">
+      match: {confidence}
+    </span>
+  </div>
+);
+
+const ProjectCard = ({ project, confidence }) => {
   const secondaryLink = project.externalLinks?.[0];
   return (
-    <article className="group overflow-hidden rounded-lg border border-white/10 bg-white/[0.04] transition-all duration-300 hover:border-accent-purple/50 hover:bg-white/[0.07]">
+    <article className="group h-full overflow-hidden rounded-lg border border-white/10 bg-white/[0.04] transition-all duration-300 hover:border-accent-purple/50 hover:bg-white/[0.07]">
       <Link
         to={`/project/${project.slug}`}
         className="block focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-purple"
@@ -14,12 +37,13 @@ const ProjectCard = ({ project }) => {
       >
         <div className="relative aspect-[4/3] overflow-hidden">
           <img
-            className="h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
+            className="h-full w-full object-cover transition-transform duration-700 group-hover:scale-110"
             alt={project.image.alt}
             src={project.image.src}
             loading="lazy"
           />
           <div className="absolute inset-0 bg-gradient-to-t from-black/85 via-black/35 to-transparent"></div>
+          <AnalysisOverlay confidence={confidence} />
           <div className="absolute bottom-0 left-0 w-full p-5">
             <div className="mb-3 inline-flex rounded-full border border-accent-purple/30 bg-accent-purple/15 px-3 py-1 text-xs font-semibold uppercase text-[#d8caff]">
               {project.category}
@@ -52,9 +76,13 @@ const ProjectCard = ({ project }) => {
 };
 
 const Portfolio = () => {
+  const reduceMotion = useReducedMotion();
+  const observeViewport = canObserveViewport();
+
   return (
-    <section id="portfolio" className="py-24 bg-[#0C0D0D]">
-      <div className="container mx-auto px-6">
+    <section id="portfolio" className="relative py-24 bg-[#0C0D0D]">
+      <div className="absolute inset-0 cv-grid" aria-hidden="true"></div>
+      <div className="container mx-auto px-6 relative">
         <div className="flex flex-col lg:flex-row gap-8 items-start justify-between">
           <div className="w-full lg:w-2/3">
             <div className="inline-block px-4 py-1.5 border border-white/20 rounded-full text-sm mb-4 uppercase">
@@ -70,11 +98,27 @@ const Portfolio = () => {
         </div>
 
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-          {featuredCaseStudies.map((project) => (
-            <ProjectCard
+          {featuredCaseStudies.map((project, index) => (
+            <motion.div
               key={project.id}
-              project={project}
-            />
+              initial={reduceMotion ? { opacity: 0 } : { opacity: 0, y: 36 }}
+              {...(observeViewport
+                ? {
+                    whileInView: reduceMotion ? { opacity: 1 } : { opacity: 1, y: 0 },
+                    viewport: { once: true, amount: 0.15 },
+                  }
+                : { animate: reduceMotion ? { opacity: 1 } : { opacity: 1, y: 0 } })}
+              transition={{
+                duration: reduceMotion ? 0.4 : 0.6,
+                delay: reduceMotion ? 0 : (index % 3) * 0.12,
+                ease: 'easeOut',
+              }}
+            >
+              <ProjectCard
+                project={project}
+                confidence={CONFIDENCE_VALUES[index % CONFIDENCE_VALUES.length]}
+              />
+            </motion.div>
           ))}
         </div>
       </div>

--- a/src/components/ProofStrip.jsx
+++ b/src/components/ProofStrip.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Award, CheckCircle2, Clock3, Gauge, Sparkles } from 'lucide-react';
+import useCountUp from '@/hooks/useCountUp';
 
 const proofItems = [
   {
@@ -29,22 +30,41 @@ const proofItems = [
   },
 ];
 
+// Splits "94% Faster" into { target: 94, suffix: '% Faster' } for count-up.
+const parseLabel = (label) => {
+  const match = /^(\d+)(.*)$/.exec(label);
+  if (!match) return null;
+  return { target: Number(match[1]), suffix: match[2] };
+};
+
+const ProofItem = ({ label, detail, icon: Icon }) => {
+  const parsed = parseLabel(label);
+  const [countRef, value] = useCountUp(parsed ? parsed.target : 0);
+  const displayLabel = parsed ? `${value}${parsed.suffix}` : label;
+
+  return (
+    <li className="flex min-h-[112px] flex-col justify-between rounded-lg border border-white/10 bg-white/[0.04] p-4">
+      <Icon className="h-5 w-5 text-accent-purple" aria-hidden="true" />
+      <div>
+        <p
+          ref={countRef}
+          className="font-mono text-base font-bold tabular-nums text-white sm:text-lg"
+        >
+          {displayLabel}
+        </p>
+        <p className="mt-1 text-xs uppercase tracking-wide text-gray-500">{detail}</p>
+      </div>
+    </li>
+  );
+};
+
 const ProofStrip = () => (
   <section className="bg-[#0C0D0D] border-y border-white/10" aria-labelledby="proof-heading">
     <div className="container mx-auto px-6 py-8">
       <h2 id="proof-heading" className="sr-only">Professional Credentials and Achievements</h2>
       <ul className="grid grid-cols-2 gap-3 md:grid-cols-5">
-        {proofItems.map(({ label, detail, icon: Icon }) => (
-          <li
-            key={label}
-            className="flex min-h-[112px] flex-col justify-between rounded-lg border border-white/10 bg-white/[0.04] p-4"
-          >
-            <Icon className="h-5 w-5 text-accent-purple" aria-hidden="true" />
-            <div>
-              <p className="text-base font-bold text-white sm:text-lg">{label}</p>
-              <p className="mt-1 text-xs uppercase tracking-wide text-gray-500">{detail}</p>
-            </div>
-          </li>
+        {proofItems.map((item) => (
+          <ProofItem key={item.label} {...item} />
         ))}
       </ul>
     </div>

--- a/src/components/ScrollProgressBar.jsx
+++ b/src/components/ScrollProgressBar.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { motion, useReducedMotion, useScroll, useSpring } from 'framer-motion';
+
+const ScrollProgressBar = () => {
+  const reduceMotion = useReducedMotion();
+  const { scrollYProgress } = useScroll();
+  const smoothProgress = useSpring(scrollYProgress, {
+    stiffness: 160,
+    damping: 28,
+    mass: 0.4,
+  });
+
+  return (
+    <motion.div
+      aria-hidden="true"
+      className="fixed inset-x-0 top-0 z-[60] h-[2px] origin-left"
+      style={{
+        scaleX: reduceMotion ? scrollYProgress : smoothProgress,
+        background: 'linear-gradient(90deg, #7C3AED, #9372FF, #D4B4FF)',
+      }}
+    />
+  );
+};
+
+export default ScrollProgressBar;

--- a/src/components/SectionAnimator.jsx
+++ b/src/components/SectionAnimator.jsx
@@ -1,16 +1,54 @@
 import React from 'react';
-import { motion } from 'framer-motion';
+import { motion, useReducedMotion } from 'framer-motion';
+
+const contentVariants = {
+  hidden: { opacity: 0, y: 50 },
+  visible: {
+    opacity: 1,
+    y: 0,
+    transition: { duration: 0.8, ease: 'easeOut' },
+  },
+};
+
+const reducedContentVariants = {
+  hidden: { opacity: 0 },
+  visible: { opacity: 1, transition: { duration: 0.4 } },
+};
+
+const scanlineVariants = {
+  hidden: { top: '0%', opacity: 0 },
+  visible: {
+    top: ['0%', '100%'],
+    opacity: [0, 0.9, 0.9, 0],
+    transition: { duration: 1.1, ease: 'easeInOut' },
+  },
+};
 
 const SectionAnimator = ({ children, className }) => {
+  const reduceMotion = useReducedMotion();
+
   return (
     <motion.div
-      initial={{ opacity: 0, y: 50 }}
-      whileInView={{ opacity: 1, y: 0 }}
+      initial="hidden"
+      whileInView="visible"
       viewport={{ once: true, amount: 0.1 }}
-      transition={{ duration: 0.8, ease: 'easeOut' }}
-      className={className}
+      className={`relative ${className ?? ''}`.trim()}
     >
-      {children}
+      <motion.div variants={reduceMotion ? reducedContentVariants : contentVariants}>
+        {children}
+      </motion.div>
+      {!reduceMotion && (
+        <motion.div
+          aria-hidden="true"
+          variants={scanlineVariants}
+          className="pointer-events-none absolute inset-x-0 z-10 h-px"
+          style={{
+            background:
+              'linear-gradient(90deg, transparent, rgba(147, 114, 255, 0.85) 20%, rgba(212, 180, 255, 0.95) 50%, rgba(147, 114, 255, 0.85) 80%, transparent)',
+            boxShadow: '0 0 12px 1px rgba(124, 58, 237, 0.55)',
+          }}
+        />
+      )}
     </motion.div>
   );
 };

--- a/src/hooks/useCountUp.js
+++ b/src/hooks/useCountUp.js
@@ -1,0 +1,56 @@
+import { useEffect, useRef, useState } from 'react';
+
+const canAnimate = () =>
+  typeof window !== 'undefined' &&
+  typeof window.IntersectionObserver === 'function' &&
+  !(window.matchMedia?.('(prefers-reduced-motion: reduce)')?.matches ?? false);
+
+/**
+ * Counts from 0 to `target` once the returned ref scrolls into view.
+ * Falls back to rendering the final value immediately when
+ * IntersectionObserver is unavailable or the user prefers reduced motion.
+ */
+const useCountUp = (target, { duration = 1400 } = {}) => {
+  const ref = useRef(null);
+  const [value, setValue] = useState(() => (canAnimate() ? 0 : target));
+
+  useEffect(() => {
+    if (!canAnimate()) {
+      setValue(target);
+      return undefined;
+    }
+
+    const node = ref.current;
+    if (!node) return undefined;
+
+    let frameId = null;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (!entries.some((entry) => entry.isIntersecting)) return;
+        observer.disconnect();
+
+        const start = performance.now();
+        const tick = (now) => {
+          const progress = Math.min((now - start) / duration, 1);
+          const eased = 1 - Math.pow(1 - progress, 3);
+          setValue(Math.round(eased * target));
+          if (progress < 1) {
+            frameId = requestAnimationFrame(tick);
+          }
+        };
+        frameId = requestAnimationFrame(tick);
+      },
+      { threshold: 0.4 },
+    );
+    observer.observe(node);
+
+    return () => {
+      observer.disconnect();
+      if (frameId !== null) cancelAnimationFrame(frameId);
+    };
+  }, [target, duration]);
+
+  return [ref, value];
+};
+
+export default useCountUp;

--- a/src/index.css
+++ b/src/index.css
@@ -92,3 +92,118 @@
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
 }
+
+/* --- CV-themed visual effects (V3 redesign) --- */
+
+/* Faint animated graph-paper texture for dark sections */
+.cv-grid {
+  pointer-events: none;
+  background-image:
+    linear-gradient(rgba(147, 114, 255, 0.045) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(147, 114, 255, 0.045) 1px, transparent 1px);
+  background-size: 48px 48px;
+  animation: cv-grid-pan 60s linear infinite;
+}
+
+@keyframes cv-grid-pan {
+  from {
+    background-position: 0 0;
+  }
+
+  to {
+    background-position: 48px 48px;
+  }
+}
+
+/* Brief RGB-split glitch + scan pass on hero H1 hover */
+.glitch-hover {
+  position: relative;
+}
+
+.glitch-hover::after {
+  content: '';
+  position: absolute;
+  left: -2%;
+  right: -2%;
+  top: 0;
+  height: 2px;
+  background: linear-gradient(90deg, transparent, rgba(212, 180, 255, 0.85), transparent);
+  opacity: 0;
+  pointer-events: none;
+}
+
+.glitch-hover:hover {
+  animation: cv-glitch 0.35s steps(2, end) 1;
+}
+
+.glitch-hover:hover::after {
+  animation: cv-h1-scan 0.5s ease-out 1;
+}
+
+@keyframes cv-glitch {
+  0%,
+  100% {
+    text-shadow: none;
+    transform: translate(0, 0);
+  }
+
+  25% {
+    text-shadow: -2px 0 rgba(255, 61, 113, 0.75), 2px 0 rgba(0, 229, 255, 0.75);
+    transform: translate(1px, -1px);
+  }
+
+  50% {
+    text-shadow: 2px 0 rgba(255, 61, 113, 0.75), -2px 0 rgba(0, 229, 255, 0.75);
+    transform: translate(-1px, 1px);
+  }
+
+  75% {
+    text-shadow: -1px 0 rgba(255, 61, 113, 0.6), 1px 0 rgba(0, 229, 255, 0.6);
+    transform: translate(1px, 0);
+  }
+}
+
+@keyframes cv-h1-scan {
+  from {
+    top: 0;
+    opacity: 1;
+  }
+
+  to {
+    top: 100%;
+    opacity: 0;
+  }
+}
+
+/* Portfolio card "analysis" scan sweep */
+.cv-card-scanline {
+  background: linear-gradient(90deg, transparent, rgba(147, 114, 255, 0.9), transparent);
+  box-shadow: 0 0 10px 1px rgba(124, 58, 237, 0.5);
+  opacity: 0;
+}
+
+.group:hover .cv-card-scanline {
+  animation: cv-card-scan 0.9s ease-in-out 1;
+}
+
+@keyframes cv-card-scan {
+  0% {
+    top: 0;
+    opacity: 1;
+  }
+
+  100% {
+    top: calc(100% - 1px);
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+
+  .cv-grid,
+  .glitch-hover:hover,
+  .glitch-hover:hover::after,
+  .group:hover .cv-card-scanline {
+    animation: none;
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Version 3 of 3: "Bold Creative"

The most distinctive option — a hand-crafted Canvas 2D experience built around your Computer Vision identity: feature-point constellations, detection brackets, scanning lines. Zero new dependencies.

### What changed
- **Hero particle constellation**: hand-rolled Canvas 2D engine — drifting feature points connected by proximity lines (CV feature-matching look), mouse repulsion, and a periodic "detection" flourish where a bounding box with corner brackets and a mono `match: 0.98` label briefly appears
- **Kinetic typography**: H1 words blur-in with stagger; gradient headline; brief glitch-scan effect on hover
- **Scanline section reveals**: a glowing purple scan line sweeps each section once as it scrolls into view (extends `SectionAnimator`, so it covers every section automatically)
- **CV-crosshair cursor**: corner brackets (⌜⌝⌞⌟) around a center dot that snap around buttons/links on hover
- **Portfolio "analysis" cards**: hover triggers corner brackets, a scan-line sweep, and a mono confidence chip, plus deeper image zoom
- **ProofStrip**: count-up stats in mono/tabular numerals for a terminal feel
- **Global**: scroll-progress bar, faint graph-paper grid texture on dark sections

### Performance & accessibility
- Particle count scales with viewport (capped 110 desktop / 55 mobile), DPR capped at 2, animation pauses when the tab is hidden or the canvas scrolls offscreen
- `prefers-reduced-motion` degrades everything to static/fade rendering
- Text readability preserved via the existing dark overlay

### Preview
[V3 hero with particle constellation](https://cursor.com/agents/bc-73111f49-9b29-4be6-b16c-14c99801f2c9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fv3-hero.png)

<details><summary>Full page</summary>
[V3 full page](https://cursor.com/agents/bc-73111f49-9b29-4be6-b16c-14c99801f2c9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fv3-full.png)
</details>

<details><summary>Original (before)</summary>
[Original hero](https://cursor.com/agents/bc-73111f49-9b29-4be6-b16c-14c99801f2c9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fcurrent-hero.png)
</details>

### Verification
- `npm test`: 85/85 passed
- `npm run build`: succeeded; zero new dependencies
- `plugins/` and `vite.config.js` (Horizons) untouched; copy, routes, SEO unchanged

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-73111f49-9b29-4be6-b16c-14c99801f2c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-73111f49-9b29-4be6-b16c-14c99801f2c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

